### PR TITLE
recipes: Update to match OE-Core virtual/cross-* changes

### DIFF
--- a/classes/clang.bbclass
+++ b/classes/clang.bbclass
@@ -119,7 +119,7 @@ def clang_base_deps(d):
             elif (d.getVar('LIBCPLUSPLUS').find('-stdlib=libc++') != -1):
                 ret += " libcxx "
             else:
-                ret += " virtual/${TARGET_PREFIX}compilerlibs "
+                ret += " virtual/${MLPREFIX}compilerlibs "
             return ret
     return ""
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -24,7 +24,7 @@ PREFERRED_PROVIDER_libgcc-initial = "libgcc-initial"
 PREFERRED_PROVIDER_llvm = "clang"
 PREFERRED_PROVIDER_llvm-native = "clang-native"
 PREFERRED_PROVIDER_nativesdk-llvm = "nativesdk-clang"
-PREFERRED_PROVIDER_libunwind = "${@bb.utils.contains_any("RUNTIME", "llvm android", "libcxx", "libunwind", d)}"
+PREFERRED_PROVIDER_libunwind = "${@bb.utils.contains_any("TC_CXX_RUNTIME", "llvm android", "libcxx", "libunwind", d)}"
 INHERIT += "clang"
 
 # Do not include clang in SDK unless user wants to

--- a/recipes-core/musl/musl_%.bbappend
+++ b/recipes-core/musl/musl_%.bbappend
@@ -1,5 +1,5 @@
 DEPENDS:append:toolchain-clang = " clang-cross-${TARGET_ARCH}"
-DEPENDS:remove:toolchain-clang = "virtual/${TARGET_PREFIX}gcc"
+DEPENDS:remove:toolchain-clang = "virtual/cross-cc"
 TOOLCHAIN:x86-x32 = "gcc"
 
 # crashes seen in malloc@plt

--- a/recipes-devtools/clang/clang-cross-canadian_git.bb
+++ b/recipes-devtools/clang/clang-cross-canadian_git.bb
@@ -12,7 +12,7 @@ require clang.inc
 require common-source.inc
 inherit cross-canadian
 
-DEPENDS += "nativesdk-clang binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/${HOST_PREFIX}binutils-crosssdk virtual/nativesdk-libc"
+DEPENDS += "nativesdk-clang binutils-cross-canadian-${TRANSLATED_TARGET_ARCH} virtual/nativesdk-cross-binutils virtual/nativesdk-libc"
 # We have to point gcc at a sysroot but we don't need to rebuild if this changes
 # e.g. we switch between different machines with different tunes.
 EXTRA_OECONF_PATHS[vardepsexclude] = "TUNE_PKGARCH"

--- a/recipes-devtools/clang/clang-cross_git.bb
+++ b/recipes-devtools/clang/clang-cross_git.bb
@@ -11,7 +11,7 @@ PN = "clang-cross-${TARGET_ARCH}"
 require clang.inc
 require common-source.inc
 inherit cross
-DEPENDS += "clang-native virtual/${TARGET_PREFIX}binutils"
+DEPENDS += "clang-native virtual/cross-binutils"
 
 do_install() {
         install -d ${D}${bindir}

--- a/recipes-devtools/clang/clang-crosssdk_git.bb
+++ b/recipes-devtools/clang/clang-crosssdk_git.bb
@@ -11,7 +11,7 @@ PN = "clang-crosssdk-${TARGET_ARCH}"
 require clang.inc
 require common-source.inc
 inherit crosssdk
-DEPENDS += "clang-native nativesdk-clang-glue virtual/${TARGET_PREFIX}binutils-crosssdk virtual/nativesdk-libc"
+DEPENDS += "clang-native nativesdk-clang-glue virtual/nativesdk-cross-binutils virtual/nativesdk-libc"
 
 do_install() {
         install -d ${D}${bindir}

--- a/recipes-devtools/clang/clang_git.bb
+++ b/recipes-devtools/clang/clang_git.bb
@@ -202,7 +202,7 @@ EXTRA_OECMAKE:append:class-target = "\
 "
 
 DEPENDS = "binutils zlib zstd libffi libxml2 libxml2-native ninja-native swig-native"
-DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_ARCH} virtual/${TARGET_PREFIX}binutils-crosssdk nativesdk-python3"
+DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_SYS} virtual/nativesdk-cross-binutils nativesdk-python3"
 DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} python3 compiler-rt libcxx"
 
 RRECOMMENDS:${PN} = "binutils"

--- a/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
+++ b/recipes-devtools/clang/compiler-rt-sanitizers_git.bb
@@ -89,7 +89,7 @@ INSANE_SKIP:${PN} = "dev-so libdir"
 INSANE_SKIP:${PN}-dbg = "libdir"
 
 #PROVIDES:append:class-target = "\
-#        virtual/${TARGET_PREFIX}compilerlibs \
+#        virtual/${MLPREFIX}compilerlibs \
 #        libgcc \
 #        libgcc-initial \
 #        libgcc-dev \

--- a/recipes-devtools/clang/compiler-rt_git.bb
+++ b/recipes-devtools/clang/compiler-rt_git.bb
@@ -106,7 +106,7 @@ INSANE_SKIP:${PN} = "dev-so libdir"
 INSANE_SKIP:${PN}-dbg = "libdir"
 
 #PROVIDES:append:class-target = "\
-#        virtual/${TARGET_PREFIX}compilerlibs \
+#        virtual/${MLPREFIX}compilerlibs \
 #        libgcc \
 #        libgcc-initial \
 #        libgcc-dev \

--- a/recipes-devtools/clang/libcxx_git.bb
+++ b/recipes-devtools/clang/libcxx_git.bb
@@ -20,12 +20,9 @@ PACKAGECONFIG[compiler-rt] = "-DLIBCXX_USE_COMPILER_RT=ON -DLIBCXXABI_USE_COMPIL
 PACKAGECONFIG[unwind-shared] = "-DLIBUNWIND_ENABLE_SHARED=ON,-DLIBUNWIND_ENABLE_SHARED=OFF,,"
 
 DEPENDS += "ninja-native"
-DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${TARGET_PREFIX}compilerlibs"
-DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_ARCH} nativesdk-compiler-rt"
-DEPENDS:append:class-native = " clang-native"
-
-LIBCPLUSPLUS = ""
-COMPILER_RT ?= "-rtlib=compiler-rt"
+DEPENDS:append:class-target = " clang-cross-${TARGET_ARCH} virtual/${MLPREFIX}libc virtual/${MLPREFIX}compilerlibs"
+DEPENDS:append:class-nativesdk = " clang-crosssdk-${SDK_SYS} nativesdk-compiler-rt"
+DEPENDS:append:class-native = " clang-native compiler-rt-native"
 
 # Trick clang.bbclass into not creating circular dependencies
 UNWINDLIB:class-nativesdk = "--unwindlib=libgcc"


### PR DESCRIPTION
Update meta-clang to match OE-Core changes to use recipe specific virtual providers (without yet switching to the new switching mechanism).

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [x] Changes have been tested
- [x] `Signed-off-by` is present
- [x] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
