### PR TITLE
clang : fix build with gcc-15

### DIFF
--- a/recipes-devtools/clang/clang/0001-ADT-Add-cstdint-to-SmallVector-101761.patch
+++ b/recipes-devtools/clang/clang/0001-ADT-Add-cstdint-to-SmallVector-101761.patch
@@ -1,0 +1,28 @@
+From 7e44305041d96b064c197216b931ae3917a34ac1 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 2 Aug 2024 23:07:21 +0100
+Subject: [PATCH] [ADT] Add `<cstdint>` to SmallVector (#101761)
+
+SmallVector uses `uint32_t`, `uint64_t` without including `<cstdint>`
+which fails to build w/ GCC 15 after a change in libstdc++ [0]
+
+[0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2
+---
+ llvm/include/llvm/ADT/SmallVector.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/include/llvm/ADT/SmallVector.h b/llvm/include/llvm/ADT/SmallVector.h
+index 09676d792dfe..17444147b102 100644
+--- a/llvm/include/llvm/ADT/SmallVector.h
++++ b/llvm/include/llvm/ADT/SmallVector.h
+@@ -19,6 +19,7 @@
+ #include <algorithm>
+ #include <cassert>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>
+-- 
+2.43.0
+

--- a/recipes-devtools/clang/clang/0001-AMDGPU-Include-cstdint-in-AMDGPUMCTargetDesc-101766.patch
+++ b/recipes-devtools/clang/clang/0001-AMDGPU-Include-cstdint-in-AMDGPUMCTargetDesc-101766.patch
@@ -1,0 +1,24 @@
+From 8f39502b85d34998752193e85f36c408d3c99248 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Sat, 3 Aug 2024 06:36:43 +0100
+Subject: [PATCH] [AMDGPU] Include `<cstdint>` in AMDGPUMCTargetDesc (#101766)
+
+---
+ llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+index 3ef00f75735b..879dbe1b279b 100644
+--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
++++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h
+@@ -15,6 +15,7 @@
+ #ifndef LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ #define LLVM_LIB_TARGET_AMDGPU_MCTARGETDESC_AMDGPUMCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ 
+ namespace llvm {
+-- 
+2.43.0
+

--- a/recipes-devtools/clang/clang/0001-Add-missing-include-to-X86MCTargetDesc.h-123320.patch
+++ b/recipes-devtools/clang/clang/0001-Add-missing-include-to-X86MCTargetDesc.h-123320.patch
@@ -1,0 +1,29 @@
+From 7abf44069aec61eee147ca67a6333fc34583b524 Mon Sep 17 00:00:00 2001
+From: Stephan Hageboeck <stephan.hageboeck@cern.ch>
+Date: Mon, 20 Jan 2025 17:52:47 +0100
+Subject: [PATCH] Add missing include to X86MCTargetDesc.h (#123320)
+
+In gcc-15, explicit includes of `<cstdint>` are required when fixed-size
+integers are used. In this file, this include only happened as a side
+effect of including SmallVector.h
+
+Although llvm compiles fine, the root-project would benefit from
+explicitly including it here, so we can backport the patch.
+
+Maybe interesting for @hahnjo and @vgvassilev
+---
+ llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+Index: git/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+===================================================================
+--- git.orig/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
++++ git/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+@@ -13,6 +13,7 @@
+ #ifndef LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ #define LLVM_LIB_TARGET_X86_MCTARGETDESC_X86MCTARGETDESC_H
+ 
++#include <cstdint>
+ #include <memory>
+ #include <string>
+ 

--- a/recipes-devtools/clang/clang/0001-ORC-RT-Add-missing-cstdint-include.patch
+++ b/recipes-devtools/clang/clang/0001-ORC-RT-Add-missing-cstdint-include.patch
@@ -1,0 +1,26 @@
+From d97981c98a70ebeaa8901f34921b0a69a068ff5d Mon Sep 17 00:00:00 2001
+From: Lang Hames <lhames@gmail.com>
+Date: Thu, 16 Nov 2023 16:45:29 -0800
+Subject: [PATCH] [ORC-RT] Add missing cstdint include.
+
+This should have been included in b2bbe8cc1c7. Adding it should fix the bot
+failures in https://lab.llvm.org/buildbot/#/builders/85/builds/20288
+---
+ compiler-rt/lib/orc/stl_extras.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/orc/stl_extras.h b/compiler-rt/lib/orc/stl_extras.h
+index 1eef56577bf8..80a6cd13ac28 100644
+--- a/compiler-rt/lib/orc/stl_extras.h
++++ b/compiler-rt/lib/orc/stl_extras.h
+@@ -13,6 +13,7 @@
+ #ifndef ORC_RT_STL_EXTRAS_H
+ #define ORC_RT_STL_EXTRAS_H
+ 
++#include <cstdint>
+ #include <utility>
+ #include <tuple>
+ 
+-- 
+2.43.0
+

--- a/recipes-devtools/clang/common.inc
+++ b/recipes-devtools/clang/common.inc
@@ -46,6 +46,10 @@ SRC_URI = "\
     file://0036-compiler-rt-Undef-_TIME_BITS-along-with-_FILE_OFFSET.patch \
     file://0037-llvm-Add-libunwind.pc.in-and-llvm-config-scripts.patch \
     file://b2929bebb6ce8d75acab4f2fde43213673cb6010.patch \
+    file://0001-Add-missing-include-to-X86MCTargetDesc.h-123320.patch \
+    file://0001-ADT-Add-cstdint-to-SmallVector-101761.patch \
+    file://0001-AMDGPU-Include-cstdint-in-AMDGPUMCTargetDesc-101766.patch \
+    file://0001-ORC-RT-Add-missing-cstdint-include.patch \
     "
 # Fallback to no-PIE if not set
 GCCPIE ??= ""


### PR DESCRIPTION
Backport patches from llvm

---
### Contributor checklist
<!-- For completed items, change [ ] to [x].  -->
- [ ] Changes have been tested
- [ ] `Signed-off-by` is present
- [ ] The PR complies with the [Open Embedded Commit Patch Message Guidelines](http://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines)

### Reviewer Guidelines
- When submitting a review, please pick:
  - '*Approve*' if this change would be acceptable in the codebase (even if there are minor or cosmetic tweaks that could be improved).
  - '*Request Changes*' if this change would not be acceptable in our codebase (e.g. bugs, changes that will make development harder in future, security/performance issues, etc).
  - '*Comment*' if you don't feel you have enough information to decide either way (e.g. if you have major questions, or you don't understand the context of the change sufficiently to fully review yourself, but want to make a comment)
